### PR TITLE
Handle min-/max-height

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 var pkg = require("./package.json");
 var postcss = require("postcss");
 
+var MIN_MAX_FEATURES = ['width', 'height'];
+
 var isSourceMapAnnotation = function (rule) {
     if (!rule) {
         return false;
@@ -91,16 +93,22 @@ var optimizeAtRuleParams = function (params) {
         
     return mapAtRuleParams
         .map(function (mqExpressions) {
-            if ( mqExpressions.hasOwnProperty('min-width') ) {
-                mqExpressions['min-width'] = mqExpressions['min-width'].reduce(function (a, b) {
-                    return ( inspectLength(a) > inspectLength(b) ) ? a : b;
-                });
-            }
-            if ( mqExpressions.hasOwnProperty('max-width') ) {
-                mqExpressions['max-width'] = mqExpressions['max-width'].reduce(function (a, b) {
-                    return ( inspectLength(a) < inspectLength(b) ) ? a : b;
-                });
-            }
+            MIN_MAX_FEATURES.forEach(function(prop) {
+                var minProp = 'min-' + prop;
+                var maxProp = 'max-' + prop;
+
+                if ( mqExpressions.hasOwnProperty(minProp) ) {
+                    mqExpressions[minProp] = mqExpressions[minProp].reduce(function (a, b) {
+                        return ( inspectLength(a) > inspectLength(b) ) ? a : b;
+                    });
+                }
+
+                if ( mqExpressions.hasOwnProperty(maxProp) ) {
+                    mqExpressions[maxProp] = mqExpressions[maxProp].reduce(function (a, b) {
+                        return ( inspectLength(a) < inspectLength(b) ) ? a : b;
+                    });
+                }
+            });
             return mqExpressions;
         }).filter(function ( e ) {
             return ( !!e['min-width'] && !!e['max-width'] ? inspectLength(e['min-width']) <= inspectLength(e['max-width']) : true );

--- a/test/mqoptimize_test.js
+++ b/test/mqoptimize_test.js
@@ -104,6 +104,19 @@ exports["Update mq - min-width x 2, same values"] = function(test){
     test.done();
 };
 
+exports["Update mq - min-height x 2, same values"] = function(test){
+    var input    = "@media (min-height: 200px) and (max-height: 300px) and (min-height: 200px) { .foo {} }";
+    var expected = "@media (min-height: 200px) and (max-height: 300px) { .foo {} }";
+    var optimized = postcss([mqoptimize()]).process(input).css; 
+        
+    test.strictEqual(
+        optimized,
+        expected
+    );
+
+    test.done();
+};
+
 exports["Update mq - min-width x 3, same values"] = function(test){
     var input    = "@media (min-width: 200px) and (max-width: 300px) and (min-width: 200px) and (min-width: 200px) { .foo {} }";
     var expected = "@media (min-width: 200px) and (max-width: 300px) { .foo {} }";
@@ -120,6 +133,19 @@ exports["Update mq - min-width x 3, same values"] = function(test){
 exports["Update mq - min-width x 2, different values"] = function(test){
     var input    = "@media (min-width: 200px) and (max-width: 300px) and (min-width: 300px) { .foo {} }";
     var expected = "@media (min-width: 300px) and (max-width: 300px) { .foo {} }";
+    var optimized = postcss([mqoptimize()]).process(input).css; 
+        
+    test.strictEqual(
+        optimized,
+        expected
+    );
+
+    test.done();
+};
+
+exports["Update mq - min-width x 2, max-height x 2, different values"] = function(test){
+    var input    = "@media (min-width: 200px) and (max-height: 300px) and (min-width: 300px) and (max-height: 400px) { .foo {} }";
+    var expected = "@media (min-width: 300px) and (max-height: 300px) { .foo {} }";
     var optimized = postcss([mqoptimize()]).process(input).css; 
         
     test.strictEqual(


### PR DESCRIPTION
This change makes it so `min-height` and `max-height` are handled similarly to `-width`.

I eventually want to expand this to support _all_ media query features that support min/max for completeness.