### PR TITLE
Don't strip values from unknown features

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,18 @@ var optimizeAtRuleParams = function (params) {
                     special = prop;
                 }
                 else {
-                    array.push( typeof e[prop] === 'string' ? '(' + prop + ': ' + e[prop] + ')' : prop );
+                    switch (typeof e[prop]) {
+                        case 'string':
+                            array.push('(' + prop + ': ' + e[prop] + ')');
+                            break;
+                        case 'object':
+                            // Handle unrecognized properties.
+                            array.push('(' + prop + ': ' + e[prop][0] + ')');
+                            break;
+                        default:
+                            // Handle specials
+                            array.push(prop);
+                    }
                 }
             }
             return ( !!special ? special + ' ' : '' ) + array.join(' and ');

--- a/test/mqoptimize_test.js
+++ b/test/mqoptimize_test.js
@@ -130,6 +130,19 @@ exports["Update mq - min-width x 2, different values"] = function(test){
     test.done();
 };
 
+exports["Update mq - leave unknown features intact"] = function(test){
+    var input    = "@media (min-width: 200px) and (max-width: 300px) and (dummy: dummyvalue) { .foo {} }";
+    var expected = "@media (min-width: 200px) and (max-width: 300px) and (dummy: dummyvalue) { .foo {} }";
+    var optimized = postcss([mqoptimize()]).process(input).css; 
+        
+    test.strictEqual(
+        optimized,
+        expected
+    );
+
+    test.done();
+};
+
 exports["Update mq - min-width x 2, different values, comma-seperated list"] = function(test){
     var input    = "@media (min-width: 200px) and (max-width: 300px) and (min-width: 300px), (min-width: 200px) { .foo {} }";
     var expected = "@media (min-width: 300px) and (max-width: 300px), (min-width: 200px) { .foo {} }";


### PR DESCRIPTION
Previously, any features that weren't either `min-width` or `max-width` would have their values stripped entirely.

This change leaves intact the values for any non-optimized features.